### PR TITLE
Placeholder selection

### DIFF
--- a/lib/js/jquery.select-hierarchy.js
+++ b/lib/js/jquery.select-hierarchy.js
@@ -88,7 +88,9 @@
                 obj.val(this_select.val());
             } else if (this_select.data('depth') > 1) {
                 obj.val(this_select.prev().val());
-            }       
+            } else {
+                obj.val('');
+            }
                
             this_select.nextAll('select').remove();
                        
@@ -98,7 +100,7 @@
 		
                 var next_select = this_select.next();
                 next_select.addClass('drilldown-' + (node.depth + 1));
-                next_select.data('depth', node.depth);
+                next_select.data('depth', node.depth + 1);
 		
                 $.each(node.children, function(){
                     var opt = $('<option>');


### PR DESCRIPTION
Previously, selecting the '------' option in either the first or
second dropdown of the hierarchy wouldn't correctly update the
original item, leading to form submissions that didn't match the
user input.
