### PR TITLE
Make the placeholder text configurable

### DIFF
--- a/lib/js/jquery.select-hierarchy.js
+++ b/lib/js/jquery.select-hierarchy.js
@@ -9,7 +9,8 @@
     $.fn.selectHierarchy = function(options) {        
         var defaults = {
             separator: ' > ',
-            hideOriginal: true
+            hideOriginal: true,
+            placeholder: '------'
         };
         var options = $.extend(defaults, options);
         var obj = $(this);
@@ -66,7 +67,7 @@
         }
         obj.attr('disabled', 'disabled');
         obj.wrap('<span class="drilldown-wrapper" />');
-        obj.after('<select class="drilldown-1"><option value="">------</option></select>');
+        obj.after('<select class="drilldown-1"><option value="">' + options.placeholder + '</option></select>');
         var root_select = obj.next();
                        
         root_select.data('depth', 1);
@@ -96,7 +97,7 @@
                        
             // Check to see if there's any children, if there are we build another select box;
             if (node && node.children.length > 0) {
-                this_select.after('<select><option value="">------</option></select>');
+                this_select.after('<select><option value="">' + options.placeholder +'</option></select>');
 		
                 var next_select = this_select.next();
                 next_select.addClass('drilldown-' + (node.depth + 1));


### PR DESCRIPTION
Add a new option, named 'placeholder', that can be set by the
caller to specify the label that should be used to indicate that
no selection has been made yet.

Keep the default value to '------', to preserve backward
compatibility.

I don't really have a strong opinion on the option name, _placeholder_
seems somehow in line with separator, but other candidates would
probably be _placeholderLabel_, _defaultLabel_, _defaultText_. If you
like another name better, just let me know ;-)
