### PR TITLE
Make page reload work

### DIFF
--- a/lib/js/jquery.select-hierarchy.js
+++ b/lib/js/jquery.select-hierarchy.js
@@ -113,5 +113,27 @@
 	        }
         }
         root_select.change(change_handler);
+
+        // After setting up the behavior, set the drilldown select lists to the correct values for
+        // forms with a default value.
+
+        // Build an object of the choices keyed by short_label.
+        var choices_by_short_label = {};
+        $.each(choices, function() {
+          choices_by_short_label[(this).short_label] = (this);
+        });
+
+        // Break selected label into segments/short_labels
+        var selected_label = obj.find(' option:selected').text();
+        var segments = selected_label.split(options.separator);
+
+        // Loop over the segments of the selected value and select the appropriate values on the
+        // drilldown select lists.
+        var counter = 1;
+        $.each(segments, function() {
+          $('select.drilldown-' + counter).val(choices_by_short_label[(this)].value);
+          $('select.drilldown-' + counter).change();
+          counter++;
+        });
     };
 })(jQuery);           


### PR DESCRIPTION
I'm opening this pull request to answer this issue. https://github.com/AndrewIngram/jquery-select-hierarchy/issues/5

I'm working in Drupal with "Exposed Filters" from the Views module. After the form is submitted it come back with the default value as the previously submitted value. That value may be three layers deep. If so, I need the drilldown select lists built back up.

There may be a cleaner way to do this bit of functionality. So far it is working in my testing.
