### PR TITLE
Check if short label exists.

### DIFF
--- a/lib/js/jquery.select-hierarchy.js
+++ b/lib/js/jquery.select-hierarchy.js
@@ -131,9 +131,11 @@
         // drilldown select lists.
         var counter = 1;
         $.each(segments, function() {
-          $('select.drilldown-' + counter, obj.parent()).val(choices_by_short_label[(this)].value);
-          $('select.drilldown-' + counter, obj.parent()).change();
+          if(choices_by_short_label[(this)]) {
+            $('select.drilldown-' + counter, obj.parent()).val(choices_by_short_label[(this)].value);
+            $('select.drilldown-' + counter, obj.parent()).change();
+          }
           counter++;
         });
     };
-})(jQuery);           
+})(jQuery);


### PR DESCRIPTION
- lib/js/jquery.select-hierarchy.js: Avoid null access error. Only set
  drilldown if choices_by_short_label entry exists.
