### PR TITLE
Selecting the preselected Options by complete label instead of short_lab...

### DIFF
--- a/lib/js/jquery.select-hierarchy.js
+++ b/lib/js/jquery.select-hierarchy.js
@@ -117,10 +117,10 @@
         // After setting up the behavior, set the drilldown select lists to the correct values for
         // forms with a default value.
 
-        // Build an object of the choices keyed by short_label.
-        var choices_by_short_label = {};
+        // Build an object of the choices keyed by label.
+        var choices_by_label = {};
         $.each(choices, function() {
-          choices_by_short_label[(this).short_label] = (this);
+          choices_by_label[(this).label] = (this);
         });
 
         // Break selected label into segments/short_labels
@@ -130,9 +130,11 @@
         // Loop over the segments of the selected value and select the appropriate values on the
         // drilldown select lists.
         var counter = 1;
+        var label = "";
         $.each(segments, function() {
-          if(choices_by_short_label[(this)]) {
-            $('select.drilldown-' + counter, obj.parent()).val(choices_by_short_label[(this)].value);
+          label += (label=="" ? "" : options.separator) +(this);
+          if(choices_by_label[label]) {
+            $('select.drilldown-' + counter, obj.parent()).val(choices_by_label[label].value);
             $('select.drilldown-' + counter, obj.parent()).change();
           }
           counter++;


### PR DESCRIPTION
...el. Otherwise it does not work if multiple options have the same short_label.
Assume:
A
A > B
C > B

Lookup by short_label will not work in case of B because the short_label is not unique. My patch solves this by looking up by label instead of short_label.
